### PR TITLE
Unpin pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     scripts=['bin/tidepy'],
     package_data={'tidepy': ["data/*.pkl"],},
     include_package_data=True,
-    install_requires=['pandas<1.1','numpy'],
+    install_requires=['pandas','numpy'],
     python_requires='>=3.4, <4',
     keywords= ['Immunotherapy', 'ICB Prediction','Biomarkers',
           'Bioinformatics', 'Computational Biology'],

--- a/tidepy/model.py
+++ b/tidepy/model.py
@@ -63,13 +63,13 @@ def tide_pred(exprsn, cancer,tide_model,pretreat=False,vthres=0):
         # use the melanoma rule for approximation
         signature_sd = signature_sd.loc['SKCM.RNASeq']
 
-    CTL_flag = exprsn.loc[set_CTL].min() > 0
+    CTL_flag = exprsn.reindex[set_CTL].min() > 0
     CTL_flag.name = 'CTL.flag'
 
     ## Adding CTL_Score
-    CTL_score = exprsn.loc[set_CTL].mean()
+    CTL_score = exprsn.reindex[set_CTL].mean()
     CTL_score.name ='CTL'
-    
+
     correlation = dysfunction_model.apply(lambda v: exprsn.corrwith(v))
     correlation = correlation.divide(signature_sd)
     correlation['TIDE'] = correlation['Exclusion']


### PR DESCRIPTION
Pinning pandas version to `<1.1` might made sense in 2020 when this change was merged. However, after 2 years pandas and Python have moved forward. If using Python 3.9+ it is now **not** possible to install `TIDEpy` since pandas<1.1 does not support Python3.9+.

We use .reindex instead of .loc in places where missing genes could break the .loc functionality. This should fix the issue #5 ,
described by @thomasyu888.