### PR TITLE
Replace pkg_resources with importlib.resources for packaged data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## System requirements
 - Linux/Unix
-- Python (>=3.4)
+- Python (>=3.9)
 
 ## Installation
 - Clone from github

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # Author            : Jingxin Fu <jingxinfu.tj@gmail.com>
 # Date              : 26/02/2020
-# Last Modified Date: 26/02/2020
+# Last Modified Date: 09/02/2026
 # Last Modified By  : Jingxin Fu <jingxinfu.tj@gmail.com>
 import setuptools
 from tidepy import __version__
@@ -24,7 +24,7 @@ setuptools.setup(
     package_data={'tidepy': ["data/*.pkl"],},
     include_package_data=True,
     install_requires=['pandas','numpy'],
-    python_requires='>=3.4, <4',
+    python_requires='>=3.9, <4',
     keywords= ['Immunotherapy', 'ICB Prediction','Biomarkers',
           'Bioinformatics', 'Computational Biology'],
     classifiers=[

--- a/tidepy/__init__.py
+++ b/tidepy/__init__.py
@@ -2,11 +2,9 @@
 # -*- coding: utf-8 -*-
 # Author            : Jingxin Fu <jingxinfu.tj@gmail.com>
 # Date              : 26/02/2020
-# Last Modified Date: 26/02/2020
+# Last Modified Date: 09/02/2026
 # Last Modified By  : Jingxin Fu <jingxinfu.tj@gmail.com>
-import os
-import pkg_resources
-__version__="1.3.8"
-DATA_DIR = pkg_resources.resource_filename('tidepy', 'data/')
-MODEL_DB_PATH = os.path.join(DATA_DIR,'model.pkl')
-GENE_REF_PATH = os.path.join(DATA_DIR,'Gene_Ref.pkl')
+
+"""TIDEpy package."""
+
+__version__ = "1.3.9"

--- a/tidepy/pred.py
+++ b/tidepy/pred.py
@@ -4,7 +4,7 @@
 # Created Date : Wednesday February 5th 2020                                   #
 # Author: Jingxin Fu (jingxinfu.tj@gmail.com)                                  #
 # ----------                                                                   #
-# Last Modified: Wednesday February 5th 2020 6:19:01 pm                        #
+# Last Modified: Monday February 9th 2026 6:19:01 pm                           #
 # Modified By: Jingxin Fu (jingxinfu.tj@gmail.com)                             #
 # ----------                                                                   #
 # Copyright (c) Jingxin Fu 2020                                                #
@@ -14,12 +14,13 @@
 __doc__="""
 """
 
-import pandas as pd
 import numpy as np
-from tidepy import utils
-from tidepy import model
-from tidepy import MODEL_DB_PATH
-MODEL_DB = pd.read_pickle(MODEL_DB_PATH)
+import warnings
+
+from tidepy import model, utils
+
+MODEL_DB = utils.read_data_object("model.pkl")
+
 def TIDE(expression, cancer, pretreat=False, vthres=0,ignore_norm=False,force_normalize=False):
     # translate the number of expression
     expression = utils.toEntrez(expression)


### PR DESCRIPTION
This pull request fixes an import-time failure in TIDEpy on modern Python environments using recent setuptools.

TIDEpy currently relies on `pkg_resources` (via `pkg_resources.resource_filename(...)`) to locate packaged data files (`model.pkl`, `Gene_Ref.pkl`). As of `setuptools>=82`, `pkg_resources` has been [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and [removed](https://setuptools.pypa.io/en/latest/history.html#v82-0-0), which causes:

`ModuleNotFoundError: No module named 'pkg_resources'`

when running `tidepy` or importing the package.

This pull request removes the `pkg_resources` dependency and switches to the stdlib `importlib.resources` API to load packaged pickles. The implementation preserves the original behavior (still uses `pandas.read_pickle`) but no longer requires filesystem paths or setuptools internals.

Changes:
- remove `pkg_resources` usage from `tidepy/__init__.py`,
- add a utility function for reading bundled pickles via `importlib.resources`,
- update `pred.py` and `utils.py` to use the new utility function.

This makes TIDEpy compatible with current setuptools releases and avoids relying on deprecated packaging APIs.